### PR TITLE
Add `--multiplicity-weighted-elbo` commandline flag 

### DIFF
--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -12,6 +12,12 @@ args_and_kwargs = (
         "default" : False,
     }),
 
+    (("--multiplicity-weighted-elbo", ), {
+        "help":"Reweight the kl_div term by multiplicity. This may perform better in some cases.",
+        "action" : "store_true",
+        "default" : False,
+    }),
+
     (("--use-weights", ),  {
         "help":"Use a weighted likelihood function.",
         "action" : "store_true",

--- a/careless/careless
+++ b/careless/careless
@@ -79,7 +79,8 @@ if parser.type == 'mono':
         anomalous=parser.anomalous, 
         dmin=parser.dmin, 
         isigi_cutoff=parser.isigi_cutoff, 
-        intensity_key=parser.intensity_key
+        intensity_key=parser.intensity_key,
+        weight_kl=parser.multiplicity_weighted_elbo,
     )
     half1,half2 = MonoMerger.half_datasets_from_mtzs(
         *parser.mtzinput, 
@@ -87,7 +88,8 @@ if parser.type == 'mono':
         seed=parser.seed,
         dmin=parser.dmin, 
         isigi_cutoff=parser.isigi_cutoff, 
-        intensity_key=parser.intensity_key
+        intensity_key=parser.intensity_key,
+        weight_kl=parser.multiplicity_weighted_elbo,
     )
 elif parser.type == 'poly':
     merger = PolyMerger.from_mtzs(
@@ -95,7 +97,8 @@ elif parser.type == 'poly':
         anomalous=parser.anomalous, 
         dmin=None, 
         isigi_cutoff=parser.isigi_cutoff, 
-        intensity_key=parser.intensity_key
+        intensity_key=parser.intensity_key,
+        weight_kl=parser.multiplicity_weighted_elbo,
     )
     half1,half2 = PolyMerger.half_datasets_from_mtzs(
         *parser.mtzinput, 
@@ -103,7 +106,8 @@ elif parser.type == 'poly':
         seed=parser.seed,
         dmin=None, 
         isigi_cutoff=parser.isigi_cutoff, 
-        intensity_key=parser.intensity_key
+        intensity_key=parser.intensity_key,
+        weight_kl=parser.multiplicity_weighted_elbo,
     )
 
     merger.expand_harmonics(

--- a/careless/merge/merge.py
+++ b/careless/merge/merge.py
@@ -45,7 +45,7 @@ class BaseMerger():
     anomalous = False
     surrogate_posterior = None
 
-    def __init__(self, datasets, anomalous=False, dmin=None, isigi_cutoff=None, intensity_key=None):
+    def __init__(self, datasets, anomalous=False, dmin=None, isigi_cutoff=None, intensity_key=None, weight_kl=False):
         """
         Parameters
         ----------
@@ -64,6 +64,7 @@ class BaseMerger():
         self.data = None
         self.cells = []
         self.spacegroups = []
+        self.weight_kl = weight_kl
         for i,ds in enumerate(datasets):
             ds = ds.copy() #Out of an abundance of caution
             ds.reset_index(inplace=True)
@@ -217,6 +218,7 @@ class BaseMerger():
             self.prior,
             self.likelihood,
             self.surrogate_posterior,
+            self.weight_kl,
         )
 
     def train_model(self, iterations, mc_samples=1, learning_rate=0.001, beta_1=0.8, beta_2=0.95, clip_value=None):


### PR DESCRIPTION
This PR adds a new flag to the CLI which controls how the ELBO is calculated. 

```
--multiplicity-weighted-elbo
                      Reweight the kl_div term by multiplicity. This may perform better in some cases.
```
When this flag is set, there are two major changes in the loss function. 
 - The log likelihood and kl_div terms are put on equal scales. This simply amounts to calling `tf.reduce_mean` instead of the historical `tf.reduce_sum`. 
 - The merger expands each of the `kl_div` terms before summing. This accounts for differences in multiplicity between reflections in the data set. 
 
 Why would I want to do this? Anecdotally, this strategy seems to produce results that are more in line with classically scaled data. So, setting this flag may lead to output that is more agreeable to downstream processing. Furthermore, this method is more readily phrased as a batched objective suitable for stochastic training. In the future, variational merging codes are most likely going to use a formulation of the ELBO like one controlled by this flag. 
 
 My inclination is that this is a superior model to the original `careless` formulation. This mode may become the new default int he future. As it stands, this claim still needs extensive validation. 