### PR TITLE
This PR adds a flag to use Nadam

### DIFF
--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -18,6 +18,12 @@ args_and_kwargs = (
         "default" : False,
     }),
 
+    (("--use-nadam", ), {
+        "help":"Instead of using the Adam optimizer, use the Nadam optimizer which has Nesterov momentum.",
+        "action" : "store_true",
+        "default" : False,
+    }),
+
     (("--use-weights", ),  {
         "help":"Use a weighted likelihood function.",
         "action" : "store_true",

--- a/careless/careless
+++ b/careless/careless
@@ -64,6 +64,7 @@ def main(merger, parser, mlp_weights=None, freeze_mlp=False):
         beta_1=parser.beta_1,
         beta_2=parser.beta_2,
         clip_value=parser.clip_value,
+        use_nadam=parser.use_nadam,
     )
     np.save(f"{parser.output_base}_losses.npy", losses)
 

--- a/careless/merge/merge.py
+++ b/careless/merge/merge.py
@@ -221,12 +221,15 @@ class BaseMerger():
             self.weight_kl,
         )
 
-    def train_model(self, iterations, mc_samples=1, learning_rate=0.001, beta_1=0.8, beta_2=0.95, clip_value=None):
+    def train_model(self, iterations, mc_samples=1, learning_rate=0.001, beta_1=0.8, beta_2=0.95, clip_value=None, use_nadam=False):
         if self.merger is None:
             self._build_merger()
 
-        optimizer = tf.keras.optimizers.Adam(learning_rate, beta_1=beta_1, beta_2=beta_2)
-        #optimizer = tf.keras.optimizers.Nadam(learning_rate, beta_1=beta_1, beta_2=beta_2)
+        if use_nadam:
+            optimizer = tf.keras.optimizers.Nadam(learning_rate, beta_1=beta_1, beta_2=beta_2)
+        else:
+            optimizer = tf.keras.optimizers.Adam(learning_rate, beta_1=beta_1, beta_2=beta_2)
+
         losses = self.merger.fit(optimizer, iterations, s=mc_samples, clip_value=clip_value)
         return losses
 


### PR DESCRIPTION
`Nadam` is the `Adam` optimizer with Nesterov acceleration instead of classical momentum. Nesterov acceleration is theoretically superior. I am unsure whether it is a better general purpose optimizer for `careless`, but I wanted to add a command line flag to enable it for the purposes of experimentation. Now running `careless` with the `--use-nadam` flag will enable `Nadam`. 