### PR TITLE
Width param

### DIFF
--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -197,6 +197,12 @@ args_and_kwargs = (
         "default":20,
     }),
 
+    (("--mlp-width",), {
+        "help": "Use a different width for the hidden layers of the neural net than the width of the metadata array.",
+        "type": int,
+        "default": None,
+    }),
+
     (("--studentt-scale",), {
         "help": "Scale parameter for variational student t likelihood.",
         "type": float,

--- a/careless/careless
+++ b/careless/careless
@@ -48,7 +48,7 @@ def main(merger, parser, mlp_weights=None, freeze_mlp=False):
         merger.add_normal_likelihood(parser.use_weights)
 
     metadata_keys = parser.metadata_keys.split(',')
-    merger.add_scaling_model(parser.sequential_layers, metadata_keys)
+    merger.add_scaling_model(parser.sequential_layers, metadata_keys, parser.mlp_width)
     if mlp_weights is not None:
         merger.scaling_model[0].set_weights(mlp_weights)
     if freeze_mlp:

--- a/careless/careless
+++ b/careless/careless
@@ -48,7 +48,7 @@ def main(merger, parser, mlp_weights=None, freeze_mlp=False):
         merger.add_normal_likelihood(parser.use_weights)
 
     metadata_keys = parser.metadata_keys.split(',')
-    merger.add_scaling_model(parser.sequential_layers, metadata_keys, parser.mlp_width)
+    merger.add_scaling_model(parser.sequential_layers, metadata_keys, width=parser.mlp_width)
     if mlp_weights is not None:
         merger.scaling_model[0].set_weights(mlp_weights)
     if freeze_mlp:

--- a/careless/merge/merge.py
+++ b/careless/merge/merge.py
@@ -350,7 +350,7 @@ class BaseMerger():
             prior = tfd.Normal(1., prior)
             self.scaling_model.append(VariationalImageScaler(self.data[image_id_key].to_numpy().astype(np.int64), prior))
 
-    def add_scaling_model(self, layers=20, metadata_keys=None, inverse_square_dHKL=True):
+    def add_scaling_model(self, layers=20, metadata_keys=None, inverse_square_dHKL=True, width=None):
         """
         Parameters
         ----------
@@ -358,9 +358,11 @@ class BaseMerger():
             Sequential dense leaky relu layers. The default is 20.
         metadata_keys : list
             List of keys to use for generating the metadata. If None, self.metadata_keys will be used.
-        invert_dHKL : bool (optional)
+        inverse_square_dHKL : bool (optional)
             Optionally transform any metadata keys named 'dHKL' by raising them to the negative 2 power.
             The default is True. 
+        width : int (optional)
+            Optionally specify a different width for the neural network than the width of the metadata array.
         """
         if metadata_keys is None:
             metadata_keys = self.metadata_keys
@@ -375,9 +377,9 @@ class BaseMerger():
         metadata = (metadata - metadata.mean(0))/metadata.std(0)
         from careless.models.scaling.nn import SequentialScaler
         if self.scaling_model is None:
-            self.scaling_model = [SequentialScaler(metadata, layers)]
+            self.scaling_model = [SequentialScaler(metadata, layers, width=width)]
         else:
-            self.scaling_model.append(SequentialScaler(metadata, layers))
+            self.scaling_model.append(SequentialScaler(metadata, layers, width=width))
 
 class HarmonicDeconvolutionMixin:
     def expand_harmonics(self, dmin=None, wavelength_key='Wavelength', wavelength_range=None):

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -8,12 +8,19 @@ class SequentialScaler(tf.keras.models.Sequential, Scaler):
     """
     Neural network based scaler with simple dense layers.
     """
-    def __init__(self, metadata, layers=20, prior=None):
+    def __init__(self, metadata, layers=20, prior=None, width=None):
         """
         Parameters
         ----------
         metadata : array 
             m x d array of reflection metadata.
+        layers : int (optional)
+            How many dense layers to add. The default is 20 layers.
+        prior : tfd.Distribution (optional)
+            An optional prior distirubtion on the scaler output.
+        width : int (optional)
+            Optionally set the width of the hidden layers to be different than the dimensions of the
+            metadata. 
         """
         super().__init__()
 
@@ -21,10 +28,12 @@ class SequentialScaler(tf.keras.models.Sequential, Scaler):
 
         self.metadata = np.array(metadata, dtype=np.float32)
         n,d = metadata.shape
+        if width is None:
+            width = d
 
         self.add(tf.keras.Input(shape=d))
         for i in range(layers):
-            self.add(tf.keras.layers.Dense(d, activation=tf.keras.layers.LeakyReLU(0.01), use_bias=True, kernel_initializer='identity'))
+            self.add(tf.keras.layers.Dense(width, activation=tf.keras.layers.LeakyReLU(0.01), use_bias=True, kernel_initializer='identity'))
             #self.add(tf.keras.layers.Dense(d, activation='softplus', use_bias=True))
         #self.add(tf.keras.layers.Dropout(0.1))
 


### PR DESCRIPTION
This adds a new parameter to the CLI, `--mlp-width=`, which can be used to control the width of the neural network layers. This is particularly useful in cases where you have a large number of metadata which would otherwise be prohibitive in terms of memory usage. 