### PR TITLE
add cli flag for positional encoding keys

### DIFF
--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -21,9 +21,19 @@ args_and_kwargs = (
 
     (("--positional-encoding-frequencies", "-L"), {
         "help":"Number of positional encoding frequencies to apply to metadata. The default is 1 which corresponds to no encoding."
-               "If you use this option, it should be paired with 'mlp-width=' in order to prevent the model from using too much memory.",
+               "If you use this option, it should be paired with 'mlp-width=' in order to prevent the model from using too much memory."
+               "By default all metadata columns will be encoded using the same formula. To encode a subset of the columns, please see"
+               "the `--positional-encoding-keys` parameter",
         "type" : int,
         "default" : 1,
+    }),
+
+    (("--positional-encoding-keys", ), {
+        "help":"If the `--positional-encoding-frequencies` flag is set to an integer > 1, this parameter enables encoding a specific subset of"
+               'of mtz columns. Supply a comma separated string of metadata keys (ie "XDET,YDET"), and these keys will be encoded separately and '
+               'appended to the rest of the metadata. ', 
+        "type" : str,
+        "default" : None,
     }),
 
     (("--use-nadam", ), {

--- a/careless/careless
+++ b/careless/careless
@@ -48,7 +48,17 @@ def main(merger, parser, mlp_weights=None, freeze_mlp=False):
         merger.add_normal_likelihood(parser.use_weights)
 
     metadata_keys = parser.metadata_keys.split(',')
-    merger.add_scaling_model(parser.sequential_layers, metadata_keys, width=parser.mlp_width, positional_encoding_frequencies=parser.positional_encoding_frequencies)
+    positional_encoding_keys = parser.positional_encoding_keys
+    if positional_encoding_keys is not None:
+        positional_encoding_keys = positional_encoding_keys.split(',')
+
+    merger.add_scaling_model(
+        parser.sequential_layers, 
+        metadata_keys, 
+        width=parser.mlp_width, 
+        positional_encoding_frequencies=parser.positional_encoding_frequencies,
+        positional_encoding_keys=positional_encoding_keys
+    )
     if mlp_weights is not None:
         merger.scaling_model[0].set_weights(mlp_weights)
     if freeze_mlp:


### PR DESCRIPTION
This pr adds a new CLI parameter `--positional-encoding-keys` which can be used to specify a subset of keys for positional encoding. It is intended to be used in conjunction with `--positional-encoding-frequencies` that controls the bit depth of the encoding. 