### PR TITLE
Experimental

### DIFF
--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -27,13 +27,6 @@ class MLPScaler(BaseModel):
 
         layers = []
 
-        layers.append(
-            tf.keras.layers.Dense(
-                width, 
-                use_bias=False, 
-                kernel_initializer='identity'
-                )
-        )
         for i in range(n_layers):
             if leakiness is None:
                 activation = tf.keras.layers.ReLU()

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -5,12 +5,13 @@ from careless.models.base import BaseModel
 import numpy as np
 
 
+
 class MLPScaler(BaseModel):
     """
     Neural network based scaler with simple dense layers.
     This neural network outputs a normal distribution.
     """
-    def __init__(self, n_layers, width):
+    def __init__(self, n_layers, width, leakiness=0.01):
         """
         Parameters
         ----------
@@ -18,15 +19,31 @@ class MLPScaler(BaseModel):
             Number of layers
         width : int
             Width of layers
+        leakiness : float or None
+            If float, use LeakyReLU activation with provided parameter. Otherwise 
+            use a simple ReLU
         """
         super().__init__()
 
         layers = []
+
+        layers.append(
+            tf.keras.layers.Dense(
+                width, 
+                use_bias=False, 
+                kernel_initializer='identity'
+                )
+        )
         for i in range(n_layers):
+            if leakiness is None:
+                activation = tf.keras.layers.ReLU()
+            else:
+                activation = tf.keras.layers.LeakyReLU(0.01)
+
             layers.append(
                 tf.keras.layers.Dense(
                     width, 
-                    activation=tf.keras.layers.LeakyReLU(), 
+                    activation=activation, 
                     use_bias=True, 
                     kernel_initializer='identity'
                     )


### PR DESCRIPTION
This PR sets the default leakiness of `ReLU` layers to `0.01`. This was the default in the old `careless`, and it seems to work a bit better for laue. 