### PR TITLE
relax ricewoolfson tolerance to prevent failures

### DIFF
--- a/tests/models/priors/test_empirical.py
+++ b/tests/models/priors/test_empirical.py
@@ -43,7 +43,7 @@ def ReferencePrior_test(p, ref, mc_samples):
     z = ref.sample(mc_samples)
     expected = ref.log_prob(z).numpy()[...,observed]
     result = p.log_prob(z).numpy()[...,observed]
-    assert np.allclose(expected, result)
+    assert np.allclose(expected, result, atol=1e-5)
 
 @pytest.mark.parametrize('mc_samples', [(), 3, 1])
 def test_LaplaceReferencePrior(mc_samples):


### PR DESCRIPTION
The ricewoolfson prior's test was asking for unreasonably tight tolerances and leading to CI failing about 10% of the time. 