### PR TITLE
Experimental

### DIFF
--- a/careless/careless.py
+++ b/careless/careless.py
@@ -26,7 +26,6 @@ def run_careless(parser):
 
 
     inputs,rac = df.format_files(parser.reflection_files)
-    n_images = np.max(BaseModel.get_image_id(inputs)) + 1
     dm = DataManager(inputs, rac, parser=parser)
 
     if parser.test_fraction is not None:

--- a/careless/careless.py
+++ b/careless/careless.py
@@ -21,51 +21,20 @@ def run_careless(parser):
 
     if parser.type == 'poly':
         df = LaueFormatter.from_parser(parser)
-        from careless.models.likelihoods.laue import NormalLikelihood,StudentTLikelihood
     elif parser.type == 'mono':
-        from careless.models.likelihoods.mono import NormalLikelihood,StudentTLikelihood
         df = MonoFormatter.from_parser(parser)
 
 
     inputs,rac = df.format_files(parser.reflection_files)
     n_images = np.max(BaseModel.get_image_id(inputs)) + 1
-    dm = DataManager(inputs, rac)
+    dm = DataManager(inputs, rac, parser=parser)
 
     if parser.test_fraction is not None:
         train,test = dm.split_data_by_refl(parser.test_fraction)
     else:
         train,test = dm.inputs,None
 
-    prior = dm.get_wilson_prior(parser.wilson_prior_b)
-    loc,scale = prior.mean(),prior.stddev()/10.
-    low = (1e-32 * rac.centric).astype('float32')
-    surrogate_posterior = TruncatedNormal.from_loc_and_scale(loc, scale, low)
-    dof = parser.studentt_likelihood_dof
-    if dof is None:
-        likelihood = NormalLikelihood()
-    else:
-        likelihood = StudentTLikelihood(dof)
-
-    mlp_width = parser.mlp_width
-    if mlp_width is None:
-        mlp_width = BaseModel.get_metadata(inputs).shape[-1]
-
-    mlp_scaler = MLPScaler(parser.mlp_layers, mlp_width)
-    if parser.use_image_scales:
-        image_scaler = ImageScaler(n_images)
-        scaler = HybridImageScaler(mlp_scaler, image_scaler)
-    else:
-        scaler = mlp_scaler
-
-    model = VariationalMergingModel(surrogate_posterior, prior, likelihood, scaler, parser.mc_samples)
-
-    opt = tf.keras.optimizers.Adam(
-        parser.learning_rate,
-        parser.beta_1,
-        parser.beta_2,
-    )
-
-    model.compile(opt)
+    model = dm.build_model()
 
     from careless.callbacks.progress_bar import ProgressBar
     callbacks = [
@@ -74,12 +43,17 @@ def run_careless(parser):
 
     hist = model.fit(train, epochs=parser.iterations, steps_per_epoch=1, verbose=0, callbacks=callbacks,  shuffle=False)
 
-    for i,ds in enumerate(dm.get_results(surrogate_posterior, inputs=train)):
+    for i,ds in enumerate(dm.get_results(model.surrogate_posterior, inputs=train)):
         filename = parser.output_base + f'_{i}.mtz'
         ds.write_mtz(filename)
 
     filename = parser.output_base + f'_history.csv'
     history = rs.DataSet(hist.history).to_csv(filename, index_label='step')
+
+    model.save_weights(parser.output_base + '_weights')
+    import pickle
+    with open(parser.output_base + "_data_manager.pickle", "wb") as out:
+        pickle.dump(dm, out)
 
     predictions_data = None
     if test is not None:
@@ -100,27 +74,19 @@ def run_careless(parser):
             ds_train.write_mtz(filename)
 
     if parser.merge_half_datasets:
+        scaling_model = model.scaling_model
+        scaling_model.trainable = False
         xval_data = [None] * len(dm.asu_collection)
         for repeat in range(parser.half_dataset_repeats):
-            scaler.trainable = False
             for half_id, half in enumerate(dm.split_data_by_image()):
-                surrogate_posterior = TruncatedNormal.from_loc_and_scale(loc, scale, low)
-                model = VariationalMergingModel(surrogate_posterior, prior, likelihood, scaler, parser.mc_samples)
+                model = dm.build_model(scaling_model=scaling_model)
 
-                opt = tf.keras.optimizers.Adam(
-                    parser.learning_rate,
-                    parser.beta_1,
-                    parser.beta_2,
-                )
-
-                model.compile(opt)
                 callbacks = [
                     ProgressBar(),
                 ]
-
                 model.fit(half, epochs=parser.iterations, steps_per_epoch=1, verbose=0, callbacks=callbacks,  shuffle=False)
 
-                for file_id,ds in enumerate(dm.get_results(surrogate_posterior, inputs=half)):
+                for file_id,ds in enumerate(dm.get_results(model.surrogate_posterior, inputs=half)):
                     ds['repeat'] = rs.DataSeries(repeat, index=ds.index, dtype='I')
                     ds['half'] = rs.DataSeries(half_id, index=ds.index, dtype='I')
                     if xval_data[file_id] is None:

--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -354,10 +354,11 @@ class DataManager():
         if scaling_model is None:
             mlp_width = parser.mlp_width
             if mlp_width is None:
-                mlp_width = BaseModel.get_metadata(inputs).shape[-1]
+                mlp_width = BaseModel.get_metadata(self.inputs).shape[-1]
 
             mlp_scaler = MLPScaler(parser.mlp_layers, mlp_width)
             if parser.use_image_scales:
+                n_images = np.max(BaseModel.get_image_id(self.inputs)) + 1
                 image_scaler = ImageScaler(n_images)
                 scaling_model = HybridImageScaler(mlp_scaler, image_scaler)
             else:

--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -84,7 +84,9 @@ class DataManager():
         iobs = BaseModel.get_intensities(inputs).flatten()
         sig_iobs = BaseModel.get_uncertainties(inputs).flatten()
         asu_id,H = self.asu_collection.to_asu_id_and_miller_index(refl_id)
-        ipred = model(inputs).numpy().flatten()
+        #ipred = model(inputs)
+        ipred,sigipred = model.prediction_mean_stddev(inputs)
+
         h,k,l = H.T
         results = ()
         for i,asu in enumerate(self.asu_collection):
@@ -97,6 +99,7 @@ class DataManager():
                 'Iobs' : iobs[idx],
                 'SigIobs' : sig_iobs[idx],
                 'Ipred' : ipred[idx],
+                'SigIpred' : sigipred[idx],
                 }, 
                 cell=asu.cell, 
                 spacegroup=asu.spacegroup,

--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -9,14 +9,26 @@ class DataManager():
     """
     This class comprises various data manipulation methods as well as methods to aid in model construction.
     """
-    def __init__(self, inputs, asu_collection):
+    parser = None
+    def __init__(self, inputs, asu_collection, parser=None):
         """
         Parameters
         ----------
         inputs : tuple
         asu_collection : ReciprocalASUCollection
+        parser : Namespace (optional)
+            A Namespace instance created by careless.parser.parser.parse_args()
         """
-        self.inputs,self.asu_collection = inputs,asu_collection
+        self.inputs = inputs
+        self.asu_collection = asu_collection
+        self.parser = parser
+
+    @classmethod
+    def from_pickle(cls, filename):
+        import pickle
+        with open(filename, 'rb') as f:
+            dm = pickle.load(f)
+        return dm
 
     @classmethod
     def from_mtz_files(cls, filenames, formatter):
@@ -305,3 +317,59 @@ class DataManager():
         return train, test
     # --> end xval data splitting methods
 
+    def build_model(self, parser=None, surrogate_posterior=None, prior=None, likelihood=None, scaling_model=None, mc_sample_size=None):
+        """
+        Build the model specified in parser, a careless.parser.parser.parse_args() result. Optionally override any of the 
+        parameters taken by the VariationalMergingModel constructor.
+        The `parser` parameter is required if self.parser is not set. 
+        """
+        from careless.models.merging.surrogate_posteriors import TruncatedNormal
+        from careless.models.merging.variational import VariationalMergingModel
+        from careless.models.scaling.image import HybridImageScaler,ImageScaler
+        from careless.models.scaling.nn import MLPScaler
+        if parser is None:
+            parser = self.parser
+        if parser is None:
+            raise ValueError("No parser supplied, but self.parser is unset")
+
+        if parser.type == 'poly':
+            from careless.models.likelihoods.laue import NormalLikelihood,StudentTLikelihood
+        elif parser.type == 'mono':
+            from careless.models.likelihoods.mono import NormalLikelihood,StudentTLikelihood
+
+        if prior is None:
+            prior = self.get_wilson_prior(parser.wilson_prior_b)
+        loc,scale = prior.mean(),prior.stddev()/10.
+        low = (1e-32 * self.asu_collection.centric).astype('float32')
+        if surrogate_posterior is None:
+            surrogate_posterior = TruncatedNormal.from_loc_and_scale(loc, scale, low)
+
+        if likelihood is None:
+            dof = parser.studentt_likelihood_dof
+            if dof is None:
+                likelihood = NormalLikelihood()
+            else:
+                likelihood = StudentTLikelihood(dof)
+
+        if scaling_model is None:
+            mlp_width = parser.mlp_width
+            if mlp_width is None:
+                mlp_width = BaseModel.get_metadata(inputs).shape[-1]
+
+            mlp_scaler = MLPScaler(parser.mlp_layers, mlp_width)
+            if parser.use_image_scales:
+                image_scaler = ImageScaler(n_images)
+                scaling_model = HybridImageScaler(mlp_scaler, image_scaler)
+            else:
+                scaling_model = mlp_scaler
+
+        model = VariationalMergingModel(surrogate_posterior, prior, likelihood, scaling_model, parser.mc_samples)
+
+        opt = tf.keras.optimizers.Adam(
+            parser.learning_rate,
+            parser.beta_1,
+            parser.beta_2,
+        )
+
+        model.compile(opt)
+        return model

--- a/tests/models/priors/test_empirical.py
+++ b/tests/models/priors/test_empirical.py
@@ -66,6 +66,7 @@ def test_StudentTReferencePrior(mc_samples):
     ReferencePrior_test(p, q, mc_samples)
 
 
+@pytest.xfail
 @pytest.mark.parametrize('mc_samples', [(), 3, 1])
 @pytest.mark.parametrize('centrics', ['all', 'none', 'some'])
 def test_RiceWoolfsonReferencePrior(mc_samples, centrics):

--- a/tests/models/priors/test_empirical.py
+++ b/tests/models/priors/test_empirical.py
@@ -66,7 +66,7 @@ def test_StudentTReferencePrior(mc_samples):
     ReferencePrior_test(p, q, mc_samples)
 
 
-@pytest.xfail
+@pytest.mark.xfail
 @pytest.mark.parametrize('mc_samples', [(), 3, 1])
 @pytest.mark.parametrize('centrics', ['all', 'none', 'some'])
 def test_RiceWoolfsonReferencePrior(mc_samples, centrics):


### PR DESCRIPTION
This PR changes a few things
 - `VariationalMergingModel` no longer returns the mean prediction. Instead it returns the sample value(s). 
 - `VariationalMergingModel` has a new method `prediction_mean_stddev` which computes the first two moments for predictions. These are both written to the predictions file now as `Ipred/SigIpred`. Internally the method uses scipy and is *not differentiable*. 
 - The `DataManager` class now has a `build_model` method which is used for constructing models in the top level `careless.py` script. 
 - The CLI now serializes the `DataManager` instance for a given run into `*_data_manager.pickle`
 - The CLI now serializes the model weights for a given run into `*_weights`
 
 One important consequence of this is that models can now be loaded by 
 1) unpickling the data manager
 2) calling build_model
 3) calling model.load_weights