### PR TITLE
Bump `rs` to v0.9.16 due to bug fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     python_requires=">=3.7,<3.10",
     url="https://github.com/Hekstra-Lab/careless",
     install_requires=[
-        "reciprocalspaceship>=0.9.15",
+        "reciprocalspaceship>=0.9.16",
         "tqdm",
         "tensorflow>=2.6",
         "tensorflow-probability",


### PR DESCRIPTION
Updating `reciprocalspaceship` version to 0.9.16 to recent bug fix ([rs#97](https://github.com/Hekstra-Lab/reciprocalspaceship/issues/97))