### PR TITLE
Add -c/--cell option to `stream2mtz`

### DIFF
--- a/scripts/stream2mtz
+++ b/scripts/stream2mtz
@@ -20,7 +20,7 @@ parser.add_argument(
     default=None,
 )
 parser.add_argument(
-    "-sg",
+    "-g",
     "--spacegroup",
     type=int,
     required=True,

--- a/scripts/stream2mtz
+++ b/scripts/stream2mtz
@@ -1,37 +1,49 @@
 #!/usr/bin/env python
-
+"""
+Convert CrystFEL stream file to an mtz for processing in careless
+"""
 import argparse
 import reciprocalspaceship as rs
 
-doc = """\
-Convert CrystFEL stream to an mtz with geometric metadata
-"""
-
 parser = argparse.ArgumentParser(
-    doc, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    formatter_class=argparse.RawTextHelpFormatter, description=__doc__
+)
 
 parser.add_argument(
-    'stream', help='File in CrystFEL stream format. Must and with .stream')
+    "stream", help="File in CrystFEL stream format. Must end with .stream"
+)
 parser.add_argument(
-    '-o',
-    '--out',
+    "-o",
+    "--out",
     type=str,
-    help='Output filename. If nothing specified, will use <streamname>.mtz',
-    default=None)
-parser.add_argument('-g',
-                    '--spacegroup',
-                    type=int,
-                    help='Space group number for the output mtz',
-                    default=1)
+    help="Output filename. If nothing specified, will use <streamname>.mtz",
+    default=None,
+)
+parser.add_argument(
+    "-sg",
+    "--spacegroup",
+    type=int,
+    required=True,
+    help="Space group number for the output mtz",
+)
+parser.add_argument(
+    "-c",
+    "--cell",
+    nargs=6,
+    metavar=("a", "b", "c", "alpha", "beta", "gamma"),
+    type=float,
+    required=True,
+    help="Cell parameters for the output mtz",
+)
+
 parser = parser.parse_args()
 
 stream = parser.stream
 out = parser.out
 
 if out is None:
-    out = stream[::-1].replace('.stream'[::-1], '.mtz'[::-1],
-                               1)[::-1]  # replace file extension only
+    out = f"{stream.removesuffix('.stream')}.mtz"  # replace file sufix
 
-table = rs.read_crystfel(stream)
-table.spacegroup = parser.spacegroup # must to that for gemmi not to complain
-table.write_mtz(out, skip_problem_mtztypes=True)
+dataset = rs.read_crystfel(stream, spacegroup=parser.spacegroup)
+dataset.cell = parser.cell
+dataset.write_mtz(out)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "scripts/ccplot",
         "scripts/ccanom_plot",
         "scripts/make_difference_map",
+        "scripts/stream2mtz",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This PR fixes #51 and includes a few updates to `stream2mtz`:
- Adds `stream2mtz` as executable when careless is installed
- Adds `-c`/`--cell` flags to provide cell parameters for new MTZ file
- Changes `-g`/`--spacegroup` to `-sg`/`--spacegroup`
- Remove default behavior of `--spacegroup` that assigned a P1 spacegroup
- Small formatting/code changes to improve readability