### PR TITLE
Save weights

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     # Skip CI if 'skip ci' is contained in latest commit message
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation will take less than five minutes on a normal desktop computer.
 ## Dependencies
 
 `careless` is likely to run on any operating system which is compatible with TensorFlow. 
-`careless` currently supports __Python 3.7 - 3.10__. 
+`careless` currently supports __Python 3.8 - 3.10__. 
 Pip will handle installation of all dependencies. 
 `careless` uses mostly tools from the conventional scientific python stack plus
  - optimization routines from [TensorFlow](https://www.tensorflow.org/)

--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -13,4 +13,16 @@ args_and_kwargs = (
         "type": int, 
         "default" : 1,
     }),
+
+    (("--structure-factor-file",), {
+        "help":"Weights file from a previous careless run to initialize the structure factors. " 
+               "This should be a string beginning with the [output_base] from a previous run (ie 'merge/hewl_structure_factor').",
+        "type": str, 
+        "default" : None,
+    }),
+
+    (("--freeze-structure-factors",), {
+        "help": "Do not optimize the structure factors.",
+        "action": "store_true"
+    }),
 )

--- a/careless/args/scaling.py
+++ b/careless/args/scaling.py
@@ -5,6 +5,18 @@ Options related to the neural network scaling model used for merging.
 
 
 args_and_kwargs = (
+    (("--scale-file",), {
+        "help": "Load scaling model weights from previous careless output. This should be a string beginning with the [output_base]"
+        "from a previous run (ie 'merge/hewl_scale').",
+        "type": str,
+        "default": None,
+    }),
+
+    (("--freeze-scales",), {
+        "help": "Do not optimize the scale model weights.",
+        "action": "store_true"
+    }),
+
     (("--mlp-layers",), {
         "help": "The number of dense neural network layers in the scaling model. The default is 20 layers.",
         "type":int,

--- a/careless/careless.py
+++ b/careless/careless.py
@@ -35,6 +35,12 @@ def run_careless(parser):
 
     model = dm.build_model()
 
+    if parser.scale_file is not None:
+        model.scaling_model.load_weights(parser.scale_file)
+    if parser.freeze_scales:
+        model.scaling_model.trainable = False
+
+
     history = model.train_model(
         tuple(map(tf.convert_to_tensor, train)),
         parser.iterations,
@@ -49,6 +55,7 @@ def run_careless(parser):
     history = rs.DataSet(history).to_csv(filename, index_label='step')
 
     model.save_weights(parser.output_base + '_weights')
+    model.scaling_model.save_weights(parser.output_base + '_scale')
     import pickle
     with open(parser.output_base + "_data_manager.pickle", "wb") as out:
         pickle.dump(dm, out)

--- a/careless/careless.py
+++ b/careless/careless.py
@@ -40,6 +40,11 @@ def run_careless(parser):
     if parser.freeze_scales:
         model.scaling_model.trainable = False
 
+    if parser.structure_factor_file is not None:
+        model.surrogate_posterior.load_weights(parser.structure_factor_file)
+    if parser.freeze_structure_factors:
+        model.surrogate_posterior.trainable = False
+
 
     history = model.train_model(
         tuple(map(tf.convert_to_tensor, train)),
@@ -54,7 +59,7 @@ def run_careless(parser):
     filename = parser.output_base + f'_history.csv'
     history = rs.DataSet(history).to_csv(filename, index_label='step')
 
-    model.save_weights(parser.output_base + '_weights')
+    model.surrogate_posterior.save_weights(parser.output_base + '_structure_factor')
     model.scaling_model.save_weights(parser.output_base + '_scale')
     import pickle
     with open(parser.output_base + "_data_manager.pickle", "wb") as out:

--- a/careless/models/merging/surrogate_posteriors.py
+++ b/careless/models/merging/surrogate_posteriors.py
@@ -52,6 +52,10 @@ class TruncatedNormal(SurrogatePosterior):
         return tf.maximum(low, s)
 
     def moment_4(self, high=np.inf):
+        """
+        Calculate the fourth moment of this distribution. This is based on the formula here: 
+        https://people.smp.uq.edu.au/YoniNazarathy/teaching_projects/studentWork/EricOrjebin_TruncatedNormalMoments.pdf
+        """
         from tensorflow_probability.python.internal.special_math import ndtr
         a,b = self.distribution.low,high
         mu,sigma = self.distribution.loc, self.distribution.scale

--- a/careless/models/merging/surrogate_posteriors.py
+++ b/careless/models/merging/surrogate_posteriors.py
@@ -120,7 +120,7 @@ class RiceWoolfson(tfd.Distribution):
         """
         self._loc   = tensor_util.convert_nonref_to_tensor(loc, dtype=tf.float32)
         self._scale = tensor_util.convert_nonref_to_tensor(scale, dtype=tf.float32)
-        self._centric = np.array(centric, dtype=np.bool)
+        self._centric = np.array(centric, dtype=bool)
         self._woolfson = FoldedNormal(self._loc, self._scale)
         self._rice = Rice(self._loc, self._scale)
         self.eps = np.finfo(np.float32).eps

--- a/careless/models/merging/surrogate_posteriors.py
+++ b/careless/models/merging/surrogate_posteriors.py
@@ -7,6 +7,9 @@ from tensorflow_probability.python.internal import tensor_util
 import tensorflow as tf
 import numpy as np
 
+class SurrogatePosterior(tf.keras.models.Model):
+    """ The base class for learnable variational distributions over structure factor amplitudes. """
+
 class RiceWoolfson(tfd.Distribution):
     def __init__(self, loc, scale, centric):
         """
@@ -54,7 +57,7 @@ class RiceWoolfson(tfd.Distribution):
 #
 #2020-11-01: On second thought, this may not be fixed unless they git rid of the current rejection sampler based 
 # implementation. See https://github.com/tensorflow/probability/issues/518, for additional issues.
-class TruncatedNormal(tfd.TruncatedNormal):
+class TruncatedNormal(SurrogatePosterior, tfd.TruncatedNormal):
     def sample(self, *args, **kwargs):
         s = super().sample(*args, **kwargs)
         low = self.low

--- a/careless/models/merging/variational.py
+++ b/careless/models/merging/variational.py
@@ -67,10 +67,7 @@ class VariationalMergingModel(tfk.Model, BaseModel):
 
         from scipy.stats import truncnorm
         q = self.surrogate_posterior
-        low,high,loc,scale = q.low.numpy(),q.high.numpy(),q.loc.numpy(),q.scale.numpy()
-        low,high = np.ones_like(loc)*low,np.ones_like(loc)*high
-        # This moment function does not vectorize for some reason
-        f4 = np.array([truncnorm.moment(4, *i) for i in zip(low, high, loc, scale)])
+        f4 = q.moment_4().numpy()
 
         s2 = np.square(scale_dist.mean().numpy()) + np.square(scale_dist.stddev().numpy())
         # var(I) = <I^2> - <I>^2

--- a/careless/models/priors/wilson.py
+++ b/careless/models/priors/wilson.py
@@ -39,7 +39,7 @@ class WilsonPrior(Prior):
             like resolution. 
         """
         self.epsilon = np.array(epsilon, dtype=np.float32)
-        self.centric = np.array(centric, dtype=np.bool)
+        self.centric = np.array(centric, dtype=bool)
         self.sigma = np.array(sigma, dtype=np.float32)
         self.p_centric = Centric(self.epsilon, self.sigma)
         self.p_acentric = Acentric(self.epsilon, self.sigma)

--- a/careless/models/scaling/base.py
+++ b/careless/models/scaling/base.py
@@ -1,0 +1,6 @@
+from careless.models.base import BaseModel
+from tensorflow import keras as tfk
+
+
+class Scaler(tfk.models.Model, BaseModel):
+    """ Base class for scaling models """

--- a/careless/models/scaling/image.py
+++ b/careless/models/scaling/image.py
@@ -1,10 +1,11 @@
 import tensorflow as tf
 from careless.models.base import BaseModel
+from careless.models.scaling.base import Scaler
 import tensorflow_probability as tfp
 import numpy as np
 
 
-class ImageScaler(BaseModel):
+class ImageScaler(Scaler):
     """
     Simple linear image scales. Average value pegged at 1.
     """
@@ -39,7 +40,7 @@ class ImageScaler(BaseModel):
         w = self.scales
         return tf.squeeze(tf.gather(w, image_ids))
 
-class HybridImageScaler(BaseModel):
+class HybridImageScaler(Scaler):
     """
     A scaler that combines an `ImageScaler` with an `MLPScaler`
     """
@@ -61,7 +62,7 @@ class HybridImageScaler(BaseModel):
         )
 
 
-class ImageLayer(BaseModel):
+class ImageLayer(Scaler):
     def __init__(self, units, max_images, activation=None, **kwargs):
         super().__init__(**kwargs)
         self.activation = tf.keras.activations.get(activation)
@@ -93,7 +94,7 @@ class ImageLayer(BaseModel):
         result = self.activation(tf.squeeze(tf.matmul(w, data[...,None]), axis=-1) + b)
         return result
 
-class NeuralImageScaler(BaseModel):
+class NeuralImageScaler(Scaler):
     def __init__(self, image_layers, max_images, mlp_layers, mlp_width, leakiness=0.01):
         super().__init__()
         layers = []

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -1,13 +1,13 @@
 import tensorflow as tf
 from tensorflow_probability import distributions as tfd
 import tensorflow_probability as tfp
-from careless.models.base import BaseModel
+from careless.models.scaling.base import Scaler
 import numpy as np
 
 
 
 
-class MetadataScaler(BaseModel):
+class MetadataScaler(Scaler):
     """
     Neural network based scaler with simple dense layers.
     This neural network outputs a normal distribution.

--- a/tests/models/merging/test_truncated_normal.py
+++ b/tests/models/merging/test_truncated_normal.py
@@ -25,3 +25,18 @@ def test_truncated_normal():
 
     assert np.all(np.isfinite(grads[0]))
     assert np.all(np.isfinite(grads[1]))
+
+def test_moment_4(npoints=100, eps=1e-3, rtol=1e-5):
+    """ Test truncated normal 4th moment against scipy.stats.truncnorm.moment """
+    loc,scale = np.random.random((2, npoints)).astype('float32')
+    scale = scale + eps
+
+    q = TruncatedNormal.from_loc_and_scale(loc, scale)
+    mom4 = q.moment_4().numpy()
+
+    from scipy.stats import truncnorm
+    low,high = 0., np.inf
+    a, b = (low - loc) / scale, (high - loc) / scale
+    mom4s = truncnorm.moment(4, a, b, loc, scale)
+    assert np.all(np.isclose(mom4, mom4s, rtol=rtol))
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,3 +97,28 @@ def test_scale_weight_save_and_load(off_file):
         out_file = out + f"_0.mtz"
         assert exists(out_file)
 
+
+def test_structure_factor_save_and_load(off_file):
+    """
+    Test saving and loading weights. 
+    """
+    with TemporaryDirectory() as td:
+        out = td + '/out'
+        flags = f"mono --disable-gpu --iterations={niter} dHKL,image_id"
+        command = flags +  f" {off_file} {out}"
+        from careless.parser import parser
+        parser = parser.parse_args(command.split())
+        run_careless(parser)
+
+        out_file = out + f"_0.mtz"
+        assert exists(out_file)
+
+        flags = flags + f" --structure-factor-file={out}_structure_factor"
+        out = td + '/out_reloaded'
+        command = flags +  f" {off_file} {out}"
+        from careless.parser import parser
+        parser = parser.parse_args(command.split())
+        run_careless(parser)
+        out_file = out + f"_0.mtz"
+        assert exists(out_file)
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,3 +72,28 @@ def test_twofile(off_file, on_file, on_file_alt_sg, ev11, dmin, anomalous, isigi
 def test_crystfel(stream_file):
     flags = f"mono --iterations={niter} --spacegroups=1 dHKL,image_id"
     base_test_together(flags, [stream_file])
+
+def test_scale_weight_save_and_load(off_file):
+    """
+    Test saving and loading weights. 
+    """
+    with TemporaryDirectory() as td:
+        out = td + '/out'
+        flags = f"mono --disable-gpu --iterations={niter} dHKL,image_id"
+        command = flags +  f" {off_file} {out}"
+        from careless.parser import parser
+        parser = parser.parse_args(command.split())
+        run_careless(parser)
+
+        out_file = out + f"_0.mtz"
+        assert exists(out_file)
+
+        flags = flags + f" --scale-file={out}_scale"
+        out = td + '/out_reloaded'
+        command = flags +  f" {off_file} {out}"
+        from careless.parser import parser
+        parser = parser.parse_args(command.split())
+        run_careless(parser)
+        out_file = out + f"_0.mtz"
+        assert exists(out_file)
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,3 +122,29 @@ def test_structure_factor_save_and_load(off_file):
         out_file = out + f"_0.mtz"
         assert exists(out_file)
 
+def test_freeze_structure_factor(off_file):
+    """ Test `--freeze-structure-factors` for execution """
+    with TemporaryDirectory() as td:
+        out = td + '/out'
+        flags = f"mono --disable-gpu --iterations={niter} --freeze-structure-factors dHKL,image_id"
+        command = flags +  f" {off_file} {out}"
+        from careless.parser import parser
+        parser = parser.parse_args(command.split())
+        run_careless(parser)
+
+        out_file = out + f"_0.mtz"
+        assert exists(out_file)
+
+def test_freeze_scales(off_file):
+    """ Test `--freeze-scales` for execution """
+    with TemporaryDirectory() as td:
+        out = td + '/out'
+        flags = f"mono --disable-gpu --iterations={niter} --freeze-scales dHKL,image_id"
+        command = flags +  f" {off_file} {out}"
+        from careless.parser import parser
+        parser = parser.parse_args(command.split())
+        run_careless(parser)
+
+        out_file = out + f"_0.mtz"
+        assert exists(out_file)
+


### PR DESCRIPTION
New CLI features
 - save scale model weights to `[output_base]_scale` 
 - save posterior model weights to `[output_base]_structure_factor`
 - optionally load scale weights with `--scale-file=[output_base]_scale`
 - optionally load posterior model weights with `--structure-factor-file=[output_base]_structure_factor`
 - optionally freeze scales during training with `--freeze-scales`
 - optionally freeze structure factors during training with `--freeze-structure-factors`
 
 API level changes
 - scale models now inherit from a base class `models.scaling.base.Scaler` which extends `tfk.models.Model`
 - surrogate posteriors now inherit from a base class `models.merging.surrogate_posteriors.SurrogatePosterior` which extends `tfk.models.Model`
 - surrogate posteriors should no longer extend `tfd.Distribution`. instead they have a `self.distribution` attribute which is assigned by the `SurrogatePosterior` constructor
 - surrogate posteriors have to implement `self.moment_4`. in the worst case, this can just be approximated by sampling or better yet quadrature (Laguerre for positive support). 