### PR TITLE
Exp bijectors & Forward looking mods

### DIFF
--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -28,8 +28,8 @@ args_and_kwargs = (
 
     (("--structure-factor-init-scale",), {
         "help":"A floating point number usually between 0 and 1. The width of the initial structure factor distribution is this times" 
-               "the standard deviation of the prior distribution. The default is 0.1. ",
+               "the standard deviation of the prior distribution. The default is 1.0. ",
         "type": float, 
-        "default" : 0.1,
+        "default" : 1.0,
     }),
 )

--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -31,5 +31,5 @@ args_and_kwargs = (
                "the standard deviation of the prior distribution. The default is 0.1. ",
         "type": float, 
         "default" : 0.1,
-    }
+    }),
 )

--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -26,10 +26,10 @@ args_and_kwargs = (
         "action": "store_true"
     }),
 
-    (("--kl-weight",), {
-        "help": "Optionally set an explicit weight for the kl divergence. This will change the reduction of likelihood and kl_divergence"
-                " from summation to means. ",
-        "type": float,
-        "default" : None,
-    })
+    (("--structure-factor-init-scale",), {
+        "help":"A floating point number usually between 0 and 1. The width of the initial structure factor distribution is this times" 
+               "the standard deviation of the prior distribution. The default is 0.1. ",
+        "type": float, 
+        "default" : 0.1,
+    }
 )

--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -25,4 +25,11 @@ args_and_kwargs = (
         "help": "Do not optimize the structure factors.",
         "action": "store_true"
     }),
+
+    (("--kl-weight",), {
+        "help": "Optionally set an explicit weight for the kl divergence. This will change the reduction of likelihood and kl_divergence"
+                " from summation to means. ",
+        "type": float,
+        "default" : None,
+    })
 )

--- a/careless/careless.py
+++ b/careless/careless.py
@@ -50,6 +50,7 @@ def run_careless(parser):
         tuple(map(tf.convert_to_tensor, train)),
         parser.iterations,
         message="Training",
+        validation_data=test,
     )
 
     for i,ds in enumerate(dm.get_results(model.surrogate_posterior, inputs=train)):

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -320,13 +320,18 @@ class MonoFormatter(DataFormatter):
             data['asu_id'].to_numpy('int64')[:,None],
             data.get_hkls(),
             )
+        iobs    = data['intensity'].to_numpy('float32')[:,None]
+        sigiobs = data['uncertainty'].to_numpy('float32')[:,None]
+        scale = 1. / iobs.mean()
+        iobs *= scale
+        sigiobs *= scale
 
         inputs = {
             'refl_id'   : refl_id[:,None],
             'image_id'  : data['image_id'].to_numpy('int64')[:,None],
             'metadata'  : metadata,
-            'intensities'   : data['intensity'].to_numpy('float32')[:,None],
-            'uncertainties' : data['uncertainty'].to_numpy('float32')[:,None],
+            'intensities'   : iobs,
+            'uncertainties' : sigiobs,
         }
 
         return self.pack_inputs(inputs), rac

--- a/careless/io/formatter.py
+++ b/careless/io/formatter.py
@@ -320,11 +320,9 @@ class MonoFormatter(DataFormatter):
             data['asu_id'].to_numpy('int64')[:,None],
             data.get_hkls(),
             )
+
         iobs    = data['intensity'].to_numpy('float32')[:,None]
         sigiobs = data['uncertainty'].to_numpy('float32')[:,None]
-        scale = 1. / iobs.mean()
-        iobs *= scale
-        sigiobs *= scale
 
         inputs = {
             'refl_id'   : refl_id[:,None],

--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -357,6 +357,7 @@ class DataManager():
             prior = DoubleWilsonPrior(self.asu_collection, parents, r_values)
 
         loc,scale = prior.mean(),prior.stddev()
+        scale = scale * parser.structure_factor_init_scale
         low = (1e-32 * ~self.asu_collection.centric).astype('float32')
         if surrogate_posterior is None:
             surrogate_posterior = TruncatedNormal.from_loc_and_scale(loc, scale, low)

--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -392,7 +392,7 @@ class DataManager():
                     scaling_model = mlp_scaler
 
         from tensorflow_probability import distributions as tfd
-        model = VariationalMergingModel(surrogate_posterior, prior, likelihood, scaling_model, parser.mc_samples, parser.kl_weight, scale_kl_weight=1., scale_prior=None)
+        model = VariationalMergingModel(surrogate_posterior, prior, likelihood, scaling_model, parser.mc_samples)
 
         opt = tf.keras.optimizers.Adam(
             parser.learning_rate,

--- a/careless/models/merging/surrogate_posteriors.py
+++ b/careless/models/merging/surrogate_posteriors.py
@@ -101,7 +101,7 @@ class TruncatedNormal(SurrogatePosterior):
             raise ValueError(f"Unknown method {method} for computing moment_4")
 
     @classmethod
-    def from_loc_and_scale(cls, loc, scale, low=0., high=1e10, scale_shift=1e-7):
+    def from_loc_and_scale(cls, loc, scale, low=0., high=1e10, scale_shift=1e-32):
         """
         Instantiate a learnable distribution with good default bijectors.
 
@@ -118,12 +118,12 @@ class TruncatedNormal(SurrogatePosterior):
         """
         loc   = tfp.util.TransformedVariable(
             loc,
-            tfb.Softplus(),
+            tfb.Exp(),
         )
         scale = tfp.util.TransformedVariable(
             scale,
             tfb.Chain([
-                tfb.Softplus(),
+                tfb.Exp(),
                 tfb.Shift(scale_shift),
             ]),
         )

--- a/careless/models/merging/variational.py
+++ b/careless/models/merging/variational.py
@@ -167,8 +167,9 @@ class VariationalMergingModel(tfk.Model, BaseModel):
                 step_data = [tf.gather(d, batch_idx) for d in data]
             else:
                 step_data = data
-            _history = train_step((self, step_data))
+            _history = self.train_on_batch(step_data, return_dict=True)
             if validation_data is not None:
+                self.train_on_batch
                 validation_metrics = self.test_on_batch(validation_data, return_dict=True)
                 _history.update({
                     k+'_val':v for k,v in validation_metrics.items()

--- a/careless/models/merging/variational.py
+++ b/careless/models/merging/variational.py
@@ -149,7 +149,7 @@ class VariationalMergingModel(tfk.Model, BaseModel):
 
         return ipred
 
-    def train_model(self, data, steps, message=None, format_string="{:0.2e}", batch_size=None):
+    def train_model(self, data, steps, message=None, format_string="{:0.2e}", batch_size=None, validation_data=None):
         """
         Alternative to the keras backed VariationalMergingModel.fit method. This method is much faster at the moment but less flexible.
         """
@@ -168,6 +168,12 @@ class VariationalMergingModel(tfk.Model, BaseModel):
             else:
                 step_data = data
             _history = train_step((self, step_data))
+            if validation_data is not None:
+                validation_metrics = self.test_on_batch(validation_data, return_dict=True)
+                _history.update({
+                    k+'_val':v for k,v in validation_metrics.items()
+                })
+
             pf = {}
             for k,v in _history.items():
                 v = float(v)
@@ -175,5 +181,7 @@ class VariationalMergingModel(tfk.Model, BaseModel):
                 if k not in history:
                     history[k] = []
                 history[k].append(v)
+
             bar.set_postfix(pf)
         return history
+

--- a/careless/models/merging/variational.py
+++ b/careless/models/merging/variational.py
@@ -149,7 +149,7 @@ class VariationalMergingModel(tfk.Model, BaseModel):
 
         return ipred
 
-    def train_model(self, data, steps, message=None, format_string="{:0.2e}"):
+    def train_model(self, data, steps, message=None, format_string="{:0.2e}", batch_size=None):
         """
         Alternative to the keras backed VariationalMergingModel.fit method. This method is much faster at the moment but less flexible.
         """
@@ -162,7 +162,12 @@ class VariationalMergingModel(tfk.Model, BaseModel):
         from tqdm import trange
         bar = trange(steps, desc=message)
         for i in bar:
-            _history = train_step((self, data))
+            if batch_size is not None:
+                batch_idx = np.sort(np.random.choice(batch_size, batch_size, replace=False)) 
+                step_data = [tf.gather(d, batch_idx) for d in data]
+            else:
+                step_data = data
+            _history = train_step((self, step_data))
             pf = {}
             for k,v in _history.items():
                 v = float(v)

--- a/careless/models/scaling/image.py
+++ b/careless/models/scaling/image.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-from tensorflow import keras as tfk
 from careless.models.base import BaseModel
 from careless.models.scaling.base import Scaler
 import tensorflow_probability as tfp
@@ -51,7 +50,8 @@ class HybridImageScaler(Scaler):
         self.image_scaler = image_scaler
 
     def call(self, inputs):
-        """ Parameters
+        """
+        Parameters
         ----------
         """
         q = self.mlp_scaler(inputs)
@@ -63,81 +63,49 @@ class HybridImageScaler(Scaler):
 
 
 class ImageLayer(Scaler):
-    def __init__(self, units, max_images, activation='ReLU', kernel_initializer='identity', bias_initializer='zeros', **kwargs):
+    def __init__(self, units, max_images, activation=None, **kwargs):
         super().__init__(**kwargs)
-        self.activation_1 = tf.keras.activations.get(activation)
-        self.activation_2 = tf.keras.activations.get(activation)
-        self.kernel_initializer = kernel_initializer
-        self.bias_initializer = bias_initializer
-
+        self.activation = tf.keras.activations.get(activation)
         self.units = units
-
         self.max_images = max_images
 
     def build(self, input_shape):
-        if self.kernel_initializer == 'identity':
-            def kernel_initializer(shape, dtype=tf.float32, **kwargs):
-                return tf.eye(shape[1], shape[2], (shape[0],), dtype=dtype)
-        else:
-            kernel_initializer = self.kernel_initializer
+        def initializer(shape, dtype=tf.float32, **kwargs):
+            return tf.eye(shape[1], shape[2], (shape[0],), dtype=dtype)
 
-        self.w_1 = self.add_weight(
-            name='kernel_1',
+        self.w = self.add_weight(
+            name='kernel',
             shape=(self.max_images, self.units, input_shape[0][-1]),
-            initializer=kernel_initializer,
+            initializer=initializer,
             trainable=True,
         )
-        self.b_1 = self.add_weight(
-            name='bias_1', 
+        self.b = self.add_weight(
+            name='bias', 
             shape=(self.max_images, self.units),
-            initializer=self.bias_initializer,
-            trainable=True,
-        )
-        self.w_2 = self.add_weight(
-            name='kernel_2',
-            shape=(self.max_images, input_shape[0][-1], self.units),
-            initializer=kernel_initializer,
-            trainable=True,
-        )
-        self.b_2 = self.add_weight(
-            name='bias_2', 
-            shape=(self.max_images, input_shape[0][-1]),
-            initializer=self.bias_initializer,
+            initializer='zeros',
             trainable=True,
         )
 
     def call(self, metadata_and_image_id, *args, **kwargs):
         data,image_id = metadata_and_image_id
         image_id = tf.squeeze(image_id)
-
-        out = data
-
-        out = self.activation_1(out)
-        w_1 = tf.gather(self.w_1, image_id, axis=0)
-        b_1 = tf.gather(self.b_1, image_id, axis=0)
-        out = tf.squeeze(tf.matmul(w_1, out[...,None]), axis=-1) + b_1
-
-        out = self.activation_2(out)
-        w_2 = tf.gather(self.w_2, image_id, axis=0)
-        b_2 = tf.gather(self.b_2, image_id, axis=0)
-        out = tf.squeeze(tf.matmul(w_2, out[...,None]), axis=-1) + b_2
-
-        return out + data
+        w = tf.gather(self.w, image_id, axis=0)
+        b = tf.gather(self.b, image_id, axis=0)
+        result = self.activation(tf.squeeze(tf.matmul(w, data[...,None]), axis=-1) + b)
+        return result
 
 class NeuralImageScaler(Scaler):
     def __init__(self, image_layers, max_images, mlp_layers, mlp_width, leakiness=0.01):
         super().__init__()
         layers = []
-
-        def kernel_initializer(shape, dtype=None, **kwargs):
-            fan_mean = 0.5*shape[-1] + 0.5*shape[-2]
-            scale = tf.sqrt(1. / 5. / mlp_layers / fan_mean)
-            tnorm = tfk.initializers.TruncatedNormal(0., scale)
-            return tnorm(shape, dtype=dtype, **kwargs)
+        if leakiness is None:
+            activation = 'ReLU'
+        else:
+            activation = tf.keras.layers.LeakyReLU(leakiness)
 
         for i in range(image_layers):
             layers.append(
-                ImageLayer(mlp_width, max_images, kernel_initializer=kernel_initializer)
+                ImageLayer(mlp_width, max_images, activation)
             )
 
         self.image_layers = layers

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -2,9 +2,39 @@ import tensorflow as tf
 from tensorflow_probability import distributions as tfd
 import tensorflow_probability as tfp
 from careless.models.scaling.base import Scaler
+from tensorflow import keras as tfk
 import numpy as np
 
 
+class NormalLayer(tfk.layers.Layer):
+    def __init__(self, eps=1e-32):
+        super().__init__()
+        self.eps = eps
+
+    def call(self, X, **kwargs):
+        loc,scale = tf.unstack(X, axis=-1)
+        scale = tf.math.exp(scale) + self.eps
+        return tfd.Normal(loc, scale)
+
+class ResnetLayer(tfk.layers.Layer):
+    def __init__(self, units, activation='ReLU', **kwargs):
+        super().__init__()
+        self._dense_kwargs = kwargs
+        self.activation_1 = tfk.activations.get(activation)
+        self.activation_2 = tfk.activations.get(activation)
+        self.units = units
+
+    def build(self, shape, **kwargs):
+        self.dense_1 = tfk.layers.Dense(self.units, **self._dense_kwargs)
+        self.dense_2 = tfk.layers.Dense(shape[-1], **self._dense_kwargs)
+
+    def call(self, X, **kwargs):
+        out = X
+        out = self.activation_1(out)
+        out = self.dense_1(out)
+        out = self.activation_2(out)
+        out = self.dense_2(out)
+        return out + X
 
 
 class MetadataScaler(Scaler):
@@ -28,35 +58,30 @@ class MetadataScaler(Scaler):
 
         mlp_layers = []
 
-        for i in range(n_layers):
-            if leakiness is None:
-                activation = tf.keras.layers.ReLU()
-            else:
-                activation = tf.keras.layers.LeakyReLU(leakiness)
-                #activation = tf.keras.activations.exponential
+        kernel_initializer = tfk.initializers.VarianceScaling(
+            scale = 1./5./n_layers,
+            mode='fan_avg', 
+            distribution='truncated_normal',
+        )
 
+        for i in range(n_layers):
             mlp_layers.append(
-                tf.keras.layers.Dense(
-                    width, 
-                    activation=activation, 
-                    use_bias=True, 
-                    kernel_initializer='identity'
-                    )
-                )
+                ResnetLayer(2*width, kernel_initializer=kernel_initializer)
+            )
 
         #The last layer is linear and generates location/scale params
         tfp_layers = []
         tfp_layers.append(
             tf.keras.layers.Dense(
-                tfp.layers.IndependentNormal.params_size(), 
+                2,
                 activation='linear', 
                 use_bias=True, 
-                kernel_initializer='identity'
+                kernel_initializer=kernel_initializer
             )
         )
 
         #The final layer converts the output to a Normal distribution
-        tfp_layers.append(tfp.layers.IndependentNormal())
+        tfp_layers.append(NormalLayer())
 
         self.network = tf.keras.Sequential(mlp_layers)
         self.distribution = tf.keras.Sequential(tfp_layers)

--- a/tests/models/merging/test_truncated_normal.py
+++ b/tests/models/merging/test_truncated_normal.py
@@ -26,13 +26,14 @@ def test_truncated_normal():
     assert np.all(np.isfinite(grads[0]))
     assert np.all(np.isfinite(grads[1]))
 
-def test_moment_4(npoints=100, eps=1e-3, rtol=1e-5):
+@pytest.mark.parametrize("method", ["scipy", "tf"])
+def test_moment_4(method, npoints=100, eps=1e-3, rtol=1e-5):
     """ Test truncated normal 4th moment against scipy.stats.truncnorm.moment """
     loc,scale = np.random.random((2, npoints)).astype('float32')
     scale = scale + eps
 
     q = TruncatedNormal.from_loc_and_scale(loc, scale)
-    mom4 = q.moment_4().numpy()
+    mom4 = q.moment_4(method=method)
 
     from scipy.stats import truncnorm
     low,high = 0., np.inf


### PR DESCRIPTION
This purpose of this PR is mostly to switch from `softplus` to `exp` bijectors for the structure factor amplitudes and `MLP` output. However, there are some other updates that are mostly in anticipation of adding features in the future. 

__API__
 - Use exp bijectors for structure factors
 - Use custome NormalLayer with exp bijector for neural net
 - Add tf and scipy methods for computing the fourth moment of posteriors
 - Add support for priors on scales in the `VariationalMergingModel`
 
 __CLI__
 - New `--structure-factor-init-scale` parameter which controls the width of the posteriors at initialization
 