### PR TITLE
Training mods

### DIFF
--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -401,5 +401,8 @@ class DataManager():
             parser.beta_2,
         )
 
-        model.compile(opt)
+        model.compile(
+            opt,
+            run_eagerly=parser.run_eagerly,
+        )
         return model

--- a/careless/parser.py
+++ b/careless/parser.py
@@ -21,10 +21,6 @@ class EnvironmentSettingsMixin(argparse.ArgumentParser):
         np.random.seed(parser.seed)
         tf.random.set_seed(parser.seed)
 
-        #Run eagerly if requested. This is very slow but needed for very large models
-        if parser.run_eagerly:
-            tf.config.run_functions_eagerly(True)
-
         #Disable the GPU if requested. This can be useful for training multiple models at the same time
         if parser.disable_gpu:
             tf.config.set_visible_devices([], 'GPU')


### PR DESCRIPTION
I'm rolling back my change to using `model.train_on_batch` as it appears to have worse performance as judged by runtime and anomalous peak heights. I have updated the custom local `train_step` to properly output training metrics. Previous versions had training metrics which were inappropriately smoothed. In addition, the model now outputs the log likelihood for the test fraction if specified. 