### PR TITLE
Add `--epsilon` CLI option

### DIFF
--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -32,4 +32,10 @@ args_and_kwargs = (
         "type": float, 
         "default" : 1.0,
     }),
+
+    (("--epsilon",), {
+        "help":"A small constant added to the scale parameters of variational distributions  for numerical stability. The default is 1e-7." ,
+        "type": float, 
+        "default" : 1e-7,
+    }),
 )

--- a/careless/io/manager.py
+++ b/careless/io/manager.py
@@ -360,7 +360,7 @@ class DataManager():
         scale = scale * parser.structure_factor_init_scale
         low = (1e-32 * ~self.asu_collection.centric).astype('float32')
         if surrogate_posterior is None:
-            surrogate_posterior = TruncatedNormal.from_loc_and_scale(loc, scale, low)
+            surrogate_posterior = TruncatedNormal.from_loc_and_scale(loc, scale, low, scale_shift=parser.epsilon)
 
         if likelihood is None:
             dof = parser.studentt_likelihood_dof
@@ -382,9 +382,10 @@ class DataManager():
                     n_images,
                     parser.mlp_layers,
                     mlp_width,
+                    epsilon=parser.epsilon,
                 )
             else:
-                mlp_scaler = MLPScaler(parser.mlp_layers, mlp_width)
+                mlp_scaler = MLPScaler(parser.mlp_layers, mlp_width, epsilon=parser.epsilon)
                 if parser.use_image_scales:
                     n_images = np.max(BaseModel.get_image_id(self.inputs)) + 1
                     image_scaler = ImageScaler(n_images)

--- a/careless/models/merging/surrogate_posteriors.py
+++ b/careless/models/merging/surrogate_posteriors.py
@@ -101,7 +101,7 @@ class TruncatedNormal(SurrogatePosterior):
             raise ValueError(f"Unknown method {method} for computing moment_4")
 
     @classmethod
-    def from_loc_and_scale(cls, loc, scale, low=0., high=1e10, scale_shift=1e-6):
+    def from_loc_and_scale(cls, loc, scale, low=0., high=1e10, scale_shift=1e-7):
         """
         Instantiate a learnable distribution with good default bijectors.
 

--- a/careless/models/merging/surrogate_posteriors.py
+++ b/careless/models/merging/surrogate_posteriors.py
@@ -101,7 +101,7 @@ class TruncatedNormal(SurrogatePosterior):
             raise ValueError(f"Unknown method {method} for computing moment_4")
 
     @classmethod
-    def from_loc_and_scale(cls, loc, scale, low=0., high=1e10, scale_shift=1e-32):
+    def from_loc_and_scale(cls, loc, scale, low=0., high=1e10, scale_shift=1e-6):
         """
         Instantiate a learnable distribution with good default bijectors.
 

--- a/careless/models/scaling/image.py
+++ b/careless/models/scaling/image.py
@@ -95,7 +95,7 @@ class ImageLayer(Scaler):
         return result
 
 class NeuralImageScaler(Scaler):
-    def __init__(self, image_layers, max_images, mlp_layers, mlp_width, leakiness=0.01):
+    def __init__(self, image_layers, max_images, mlp_layers, mlp_width, leakiness=0.01, epsilon=1e-7):
         super().__init__()
         layers = []
         if leakiness is None:
@@ -110,7 +110,7 @@ class NeuralImageScaler(Scaler):
 
         self.image_layers = layers
         from careless.models.scaling.nn import MetadataScaler
-        self.metadata_scaler = MetadataScaler(mlp_layers, mlp_width, leakiness)
+        self.metadata_scaler = MetadataScaler(mlp_layers, mlp_width, leakiness, epsilon=epsilon)
 
     def call(self, inputs):
         result = self.get_metadata(inputs)

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 class NormalLayer(tf.keras.layers.Layer):
-    def __init__(self, scale_bijector=None, epsilon=1e-32, **kwargs): 
+    def __init__(self, scale_bijector=None, epsilon=1e-7, **kwargs): 
         super().__init__(**kwargs)
         self.epsilon = epsilon
         if scale_bijector is None:

--- a/careless/models/scaling/nn.py
+++ b/careless/models/scaling/nn.py
@@ -28,7 +28,7 @@ class MetadataScaler(Scaler):
     Neural network based scaler with simple dense layers.
     This neural network outputs a normal distribution.
     """
-    def __init__(self, n_layers, width, leakiness=0.01):
+    def __init__(self, n_layers, width, leakiness=0.01, epsilon=1e-7):
         """
         Parameters
         ----------
@@ -73,7 +73,7 @@ class MetadataScaler(Scaler):
 
         #The final layer converts the output to a Normal distribution
         #tfp_layers.append(tfp.layers.IndependentNormal())
-        tfp_layers.append(NormalLayer())
+        tfp_layers.append(NormalLayer(epsilon=epsilon))
 
         self.network = tf.keras.Sequential(mlp_layers)
         self.distribution = tf.keras.Sequential(tfp_layers)


### PR DESCRIPTION
Add an `--epsilon` parameter to the CLI which controls the minimum values of the surrogate posterior scale parameters. 