### PR TITLE
improve help strings for transfer learning options

### DIFF
--- a/careless/args/common.py
+++ b/careless/args/common.py
@@ -15,11 +15,13 @@ args_and_kwargs = (
     }),
 
     (("--structure-factor-file",), {
-        "help":"Weights file from a previous careless run to initialize the structure factors. " 
-               "This should be a string beginning with the [output_base] from a previous run (ie 'merge/hewl_structure_factor').",
+        "help": "Initialize the structure factors from the ouput of a previous run. This argument should be a string beginning with the "
+                "base filename used in the previous run and ending in _structure_factor.  For instance, if the previous run "
+                "was called with `careless mono [...] merge/hewl`, the appropriate filename to use would be merge/hewl_structure_factor. ",
         "type": str, 
         "default" : None,
     }),
+
 
     (("--freeze-structure-factors",), {
         "help": "Do not optimize the structure factors.",

--- a/careless/args/scaling.py
+++ b/careless/args/scaling.py
@@ -6,8 +6,9 @@ Options related to the neural network scaling model used for merging.
 
 args_and_kwargs = (
     (("--scale-file",), {
-        "help": "Load scaling model weights from previous careless output. This should be a string beginning with the [output_base]"
-        "from a previous run (ie 'merge/hewl_scale').",
+        "help": "Initialize the scale model weights from the ouput of a previous run. This argument should be a string beginning with the "
+                "base filename used in the previous run and ending in _scale.  For instance, if the previous run "
+                "was called with `careless mono [...] merge/hewl`, the appropriate file name would be merge/hewl_scale. ",
         "type": str,
         "default": None,
     }),


### PR DESCRIPTION
Addressing #63 which noted that the help strings related to loading weights from previous runs were confusing. 