### PR TITLE
fix --run-eagerly

### DIFF
--- a/careless/models/merging/variational.py
+++ b/careless/models/merging/variational.py
@@ -159,7 +159,7 @@ class VariationalMergingModel(tfk.Model, BaseModel):
             history = model.train_step((data,))
             return history
 
-        if self._run_eagerly:
+        if not self._run_eagerly:
             train_step = tf.function(train_step, reduce_retracing=True)
 
         if validation_data is not None:


### PR DESCRIPTION
A previous commit broke the --run-eagerly flag. Specifically, the default behavior in the previous version was to use eager execution and --run-eagerly used tf.function to compile the model.